### PR TITLE
Add configurable capture interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can send this archive to Enigma support for troubleshooting.
 - **On Linux, the install script creates config at:** `/etc/enigma-agent/config.json` if it does not exist. Edit this file after install to adjust settings.
 - **Key fields:**
   - `logging`: Log level, file path, and max size.
-  - `capture`: Output directory, interval, and window duration.
+  - `capture`: Output directory, interval, window duration, and interface.
   - `enigma_api`: API server, API key, upload toggle (always enabled).
   - `log_retention_days`: Number of days to keep log files. Logs older than this are deleted on startup. Default: 1
 - **How to configure:**

--- a/cmd/enigma-agent/main.go
+++ b/cmd/enigma-agent/main.go
@@ -126,6 +126,7 @@ func main() {
 	capCfg := common.CaptureConfig{
 		CaptureWindow: window,
 		OutputDir:     cfg.Capture.OutputDir, // Will be overridden per iteration
+		Interface:     cfg.Capture.Interface,
 	}
 	capturer := capture.NewCapturer(capCfg)
 	proc := processor.NewProcessor()

--- a/config.example.json
+++ b/config.example.json
@@ -8,7 +8,8 @@
   "capture": {
     "output_dir": "./captures",
     "window_seconds": 60,
-    "loop": false
+    "loop": false,
+    "interface": "any"
   },
   "enigma_api": {
     "server": "api.enigmaai.net:443",

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 		WindowSeconds int `json:"window_seconds"`
 		// Loop determines if the agent should run in a continuous loop
 		Loop bool `json:"loop"`
+		// Interface specifies which network interface to capture from. "any" captures on every interface
+		Interface string `json:"interface"`
 	} `json:"capture"`
 
 	// Enigma API configuration
@@ -84,6 +86,9 @@ func LoadConfig(configPath string) (*Config, error) {
 	}
 	if config.Capture.Loop != true {
 		config.Capture.Loop = false
+	}
+	if config.Capture.Interface == "" {
+		config.Capture.Interface = "any"
 	}
 	// Zeek path can be empty by default
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -276,6 +276,7 @@ func RunAgent(ctx context.Context, cfg *config.Config, capturer Capturer, proces
 		capCfg := common.CaptureConfig{
 			CaptureWindow: window,
 			OutputDir:     zeekOutDir,
+			Interface:     cfg.Capture.Interface,
 		}
 		log.Printf("Starting capture iteration at %s", timestamp)
 		pcapPath, err := capturer.Capture(ctx, capCfg)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -78,10 +78,12 @@ func minimalConfig(loop bool) *config.Config {
 			OutputDir     string `json:"output_dir"`
 			WindowSeconds int    `json:"window_seconds"`
 			Loop          bool   `json:"loop"`
+			Interface     string `json:"interface"`
 		}{
 			OutputDir:     "/tmp",
 			WindowSeconds: 0,
 			Loop:          loop,
+			Interface:     "any",
 		},
 		Logging: struct {
 			Level            string `json:"level"`

--- a/internal/capture/common/capture.go
+++ b/internal/capture/common/capture.go
@@ -10,6 +10,7 @@ type CaptureConfig struct {
 	CaptureWindow   time.Duration // Duration of each capture window
 	CaptureInterval time.Duration // Interval between capture starts
 	OutputDir       string        // Directory to store capture output
+	Interface       string        // Network interface to capture from ("any" for all interfaces)
 }
 
 // CaptureResult represents the result of a single capture operation

--- a/internal/capture/linux/capture.go
+++ b/internal/capture/linux/capture.go
@@ -47,8 +47,12 @@ func (c *LinuxCapturer) runCapture(ctx context.Context, config common.CaptureCon
 	outputFile := filepath.Join(c.outputDir, fmt.Sprintf("capture_%s.pcap", timestamp))
 
 	// Build tcpdump command
+	iface := "any"
+	if config.Interface != "" && config.Interface != "any" && config.Interface != "all" {
+		iface = config.Interface
+	}
 	args := []string{
-		"-i", "any", // Capture on all interfaces
+		"-i", iface, // Capture on specified interface
 		"-w", outputFile, // Write to file
 		"-G", fmt.Sprintf("%d", int(config.CaptureWindow.Seconds())), // Rotate after duration
 		"-W", "1", // Create only one file

--- a/internal/capture/linux/capture_test.go
+++ b/internal/capture/linux/capture_test.go
@@ -14,6 +14,7 @@ import (
 
 // mockCmd is a mock for exec.Cmd
 var mockRunError error
+var gotArgs []string
 
 // TestLinuxCapturer_Capture_Success verifies that the LinuxCapturer successfully captures data when the command executes without error.
 func TestLinuxCapturer_Capture_Success(t *testing.T) {
@@ -25,11 +26,13 @@ func TestLinuxCapturer_Capture_Success(t *testing.T) {
 		CaptureWindow:   1 * time.Second,
 		CaptureInterval: 1 * time.Second,
 		OutputDir:       "/tmp",
+		Interface:       "eth0",
 	}
 
 	// Patch commandContext to return a dummy Cmd
 	origCommandContext := commandContext
 	commandContext = func(name string, arg ...string) *exec.Cmd {
+		gotArgs = arg
 		return exec.Command("echo")
 	}
 	defer func() { commandContext = origCommandContext }()
@@ -37,6 +40,15 @@ func TestLinuxCapturer_Capture_Success(t *testing.T) {
 	_, err := c.Capture(ctx, config)
 	if err != nil {
 		t.Fatalf("Capture() error = %v", err)
+	}
+	found := false
+	for i := range gotArgs {
+		if gotArgs[i] == "eth0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected interface arg 'eth0', got %v", gotArgs)
 	}
 }
 

--- a/internal/capture/windows/capture.go
+++ b/internal/capture/windows/capture.go
@@ -47,6 +47,14 @@ func (c *WindowsCapturer) runCapture(ctx context.Context, config common.CaptureC
 	timestamp := time.Now().Format("20060102_150405")
 	etlFile := fmt.Sprintf("%s/capture_%s.etl", c.outputDir, timestamp)
 
+	if config.Interface != "" && config.Interface != "any" && config.Interface != "all" {
+		addCmd := commandContext("pktmon", "filter", "add", "-i", config.Interface)
+		if err := addCmd.Run(); err != nil {
+			return "", fmt.Errorf("failed to add pktmon filter: %v", err)
+		}
+		defer commandContext("pktmon", "filter", "remove").Run()
+	}
+
 	// Start pktmon capture
 	log.Printf("[capture] Running pktmon command: pktmon start --capture --file %s", etlFile)
 	c.cmd = commandContext("pktmon", "start", "--capture", "--file", etlFile)


### PR DESCRIPTION
## Summary
- allow setting capture interface in configuration with default `any`
- make capture modules honor the interface, treating `any` or `all` as "capture everything"
- keep example config and tests updated for new default

## Testing
- `go mod download`
- `go test -i ./...` *(fails: no Go files in module root)*
- `GOOS=linux GOARCH=amd64 go test ./...`
- `GOOS=windows GOARCH=amd64 go test ./...` *(fails: exec format error)*
- `GOOS=darwin GOARCH=amd64 go test ./...` *(fails: exec format error)*
- `golangci-lint run ./...` *(fails with existing issues)*